### PR TITLE
Fixed bug with universe filter node

### DIFF
--- a/src/model/filter.py
+++ b/src/model/filter.py
@@ -1,6 +1,10 @@
 # coding=utf-8
 """Filter module"""
+from typing import TYPE_CHECKING
 from enum import IntFlag, auto
+
+if TYPE_CHECKING:
+    from . import Scene
 
 class DataType(IntFlag):
     """Data types used by filter channels"""

--- a/src/view/show_mode/node_graphics_item.py
+++ b/src/view/show_mode/node_graphics_item.py
@@ -120,7 +120,7 @@ class FilterSettingsDialog(QDialog):
             return key
         # Fetch universe
         universe_id = int(self.filter.filter_configurations["universe"])
-        for uni in self.filter.board_configuration.universes:
+        for uni in self.filter.scene.board_configuration.universes:
             if uni.universe_proto.id == universe_id:
                 universe = uni
                 break


### PR DESCRIPTION
When opening the filter settings of a universe filter, patching info could not be fetched. Adjusted call to board configuration