### PR TITLE
add: shift filter prototype

### DIFF
--- a/src/view/show_mode/editor/filter_node_library.py
+++ b/src/view/show_mode/editor/filter_node_library.py
@@ -98,5 +98,8 @@ class FilterNodeLibrary(NodeLibrary):
         self.addNodeType(nodes.FaderHSIAUNode, [('Filter Fader',)])
 
     def _register_effect_nodes(self):
-        # TODO register shift filters
         self.addNodeType(nodes.CueListNode, [('Effects',)])
+        self.addNodeType(nodes.Shift8BitNode, [('Effects',)])
+        self.addNodeType(nodes.Shift16BitNode, [('Effects',)])
+        self.addNodeType(nodes.ShiftFloatNode, [('Effects',)])
+        self.addNodeType(nodes.ShiftColorNode, [('Effects',)])

--- a/src/view/show_mode/editor/filter_settings_item.py
+++ b/src/view/show_mode/editor/filter_settings_item.py
@@ -159,6 +159,8 @@ class FilterSettingsDialog(QDialog):
     def closeEvent(self, arg__1: PySide6.QtGui.QCloseEvent) -> None:
         if self._special_widget:
             self._special_widget.parent_closed(self._filter_node)
+        else:
+            self._filter_node.update_node_after_settings_changed()
         super().closeEvent(arg__1)
 
     def show(self) -> None:

--- a/src/view/show_mode/editor/node_editor_widgets/cue_editor/cue_editor_widget.py
+++ b/src/view/show_mode/editor/node_editor_widgets/cue_editor/cue_editor_widget.py
@@ -357,6 +357,7 @@ class CueEditor(NodeEditorFilterConfigWidget):
             self._broadcaster.jogwheel_rotated_left.disconnect(self.jg_left)
             self._broadcaster.desk_media_scrub_pressed.disconnect(self.scrub_pressed)
             self._broadcaster.desk_media_scrub_released.disconnect(self.scrub_released)
+        super().parent_closed(filter_node)
 
     def parent_opened(self):
         self._input_dialog = YesNoDialog(self.get_widget(), self._link_bankset)

--- a/src/view/show_mode/editor/node_editor_widgets/node_editor_widget.py
+++ b/src/view/show_mode/editor/node_editor_widgets/node_editor_widget.py
@@ -51,7 +51,7 @@ class NodeEditorFilterConfigWidget(ABC):
         """This method might be overridden to listen for parent close events.
         Arguments:
             filter_node -- might be used to alter the filter being presented."""
-        pass
+        filter_node.update_node_after_settings_changed()
 
     def parent_opened(self):
         """This method might be overridden to listen for parent open events."""

--- a/src/view/show_mode/editor/nodes/__init__.py
+++ b/src/view/show_mode/editor/nodes/__init__.py
@@ -57,6 +57,9 @@ type_to_node: dict[int, str] = {
         42: FaderHSIUNode.nodeName,
         43: FaderHSIAUNode.nodeName,
         44: CueListNode.nodeName,
-        # TODO add shift filters
+        45: Shift8BitNode.nodeName,
+        46: Shift16BitNode.nodeName,
+        47: ShiftFloatNode.nodeName,
+        48: ShiftColorNode.nodeName,
         49: FaderMainBrightness.nodeName,
     }

--- a/src/view/show_mode/editor/nodes/effects.py
+++ b/src/view/show_mode/editor/nodes/effects.py
@@ -1,4 +1,4 @@
-from model import DataType
+from model import DataType, Scene
 from model.broadcaster import Broadcaster
 from .filternode import FilterNode
 
@@ -55,8 +55,18 @@ class ShiftFilterNode(FilterNode):
         self.filter.in_data_types["time"] = DataType.DT_DOUBLE
 
         try:
-            print(dir(model))
-            self.filter.filter_configurations["nr_outputs"] = str(int(model.filter_configurations.get("nr_outputs")))
+            if isinstance(model, Scene):
+                found = False
+                for f in model.filters:
+                    if id == f.filter_id:
+                        self.filter.filter_configurations["nr_outputs"] = str(
+                            int(f.filter_configurations.get("nr_outputs")))
+                        found = True
+                        break
+                if not found:
+                    self.filter.filter_configurations["nr_outputs"] = "0"
+            else:
+                self.filter.filter_configurations["nr_outputs"] = str(int(model.filter_configurations.get("nr_outputs")))
         except ValueError:
             self.filter.filter_configurations["nr_outputs"] = "0"
 

--- a/src/view/show_mode/editor/nodes/effects.py
+++ b/src/view/show_mode/editor/nodes/effects.py
@@ -44,11 +44,11 @@ class CueListNode(FilterNode):
 
 class ShiftFilterNode(FilterNode):
     def __init__(self, model, name, id: int, data_type: DataType):
-        super().__init__(model=model, filter_type=id, name=name, allowAddOutput=True) #, terminals={
-            #'input': {'io': 'in'},
-            #'switch_time': {'io', 'in'},
-            #'time': {'io': 'in'},
-        #}, )
+        super().__init__(model=model, filter_type=id, name=name, allowAddOutput=True, terminals={
+            'input': {'io': 'in'},
+            'switch_time': {'io', 'in'},
+            'time': {'io': 'in'},
+        }, )
 
         self.filter.in_data_types["input"] = data_type
         self.filter.in_data_types["switch_time"] = DataType.DT_DOUBLE

--- a/src/view/show_mode/editor/nodes/effects.py
+++ b/src/view/show_mode/editor/nodes/effects.py
@@ -9,8 +9,8 @@ class CueListNode(FilterNode):
 
     def __init__(self, model, name):
         super().__init__(model=model, filter_type=44, name=name, terminals={
-            'time': {'io': 'in'}},
-                         allowAddOutput=True)
+            'time': {'io': 'in'}
+        }, allowAddOutput=True)
 
         try:
             mapping_from_file = model.initial_parameters["mapping"]
@@ -41,4 +41,54 @@ class CueListNode(FilterNode):
                     self.addOutput(channel_name)
                     self.filter.out_data_types[channel_name] = channel_type
 
-    # TODO implement shift effect nodes
+
+class ShiftFilterNode(FilterNode):
+    def __init__(self, model, name, id: int, data_type: DataType):
+        super().__init__(model=model, filter_type=id, name=name, allowAddOutput=True) #, terminals={
+            #'input': {'io': 'in'},
+            #'switch_time': {'io', 'in'},
+            #'time': {'io': 'in'},
+        #}, )
+
+        self.filter.in_data_types["input"] = data_type
+        self.filter.in_data_types["switch_time"] = DataType.DT_DOUBLE
+        self.filter.in_data_types["time"] = DataType.DT_DOUBLE
+
+        try:
+            print(dir(model))
+            self.filter.filter_configurations["nr_outputs"] = str(int(model.filter_configurations.get("nr_outputs")))
+        except ValueError:
+            self.filter.filter_configurations["nr_outputs"] = "0"
+
+        for i in range(int(self.filter.filter_configurations["nr_outputs"])):
+            channel_name = "output_" + str(i + 1)
+            self.addOutput(channel_name)
+            self.filter.out_data_types[channel_name] = data_type
+
+
+class Shift8BitNode(ShiftFilterNode):
+    nodeName = "filter_shift_8bit"
+
+    def __init__(self, model, name):
+        super().__init__(model, name, 45, DataType.DT_8_BIT)
+
+
+class Shift16BitNode(ShiftFilterNode):
+    nodeName = "filter_shift_16bit"
+
+    def __init__(self, model, name):
+        super().__init__(model, name, 46, DataType.DT_16_BIT)
+
+
+class ShiftFloatNode(ShiftFilterNode):
+    nodeName = "filter_shift_float"
+
+    def __init__(self, model, name):
+        super().__init__(model, name, 47, DataType.DT_DOUBLE)
+
+
+class ShiftColorNode(ShiftFilterNode):
+    nodeName = "filter_shift_color"
+
+    def __init__(self, model, name):
+        super().__init__(model, name, 48, DataType.DT_COLOR)

--- a/src/view/show_mode/editor/nodes/effects.py
+++ b/src/view/show_mode/editor/nodes/effects.py
@@ -46,8 +46,8 @@ class ShiftFilterNode(FilterNode):
     def __init__(self, model, name, id: int, data_type: DataType):
         super().__init__(model=model, filter_type=id, name=name, allowAddOutput=True, terminals={
             'input': {'io': 'in'},
-            'switch_time': {'io', 'in'},
-            'time': {'io': 'in'},
+            'switch_time': {'io': 'in'},
+            'time': {'io': 'in'}
         }, )
 
         self.filter.in_data_types["input"] = data_type

--- a/src/view/show_mode/editor/nodes/effects.py
+++ b/src/view/show_mode/editor/nodes/effects.py
@@ -70,10 +70,26 @@ class ShiftFilterNode(FilterNode):
         except ValueError:
             self.filter.filter_configurations["nr_outputs"] = "0"
 
-        for i in range(int(self.filter.filter_configurations["nr_outputs"])):
-            channel_name = "output_" + str(i + 1)
-            self.addOutput(channel_name)
-            self.filter.out_data_types[channel_name] = data_type
+        self._data_type = data_type
+        self.setup_output_terminals()
+
+    def setup_output_terminals(self):
+        existing_output_keys = [k for k in self.outputs().keys()]
+        previous_output_count = len(existing_output_keys)
+        new_output_count = int(self.filter.filter_configurations["nr_outputs"])
+        if previous_output_count > new_output_count:
+            for i in range(previous_output_count - new_output_count):
+                key_to_drop = existing_output_keys[len(existing_output_keys) - i - 1]
+                self.removeTerminal(key_to_drop)
+        else:
+            for i in range(new_output_count):
+                if i >= previous_output_count:
+                    channel_name = "output_" + str(i + 1)
+                    self.addOutput(channel_name)
+                    self.filter.out_data_types[channel_name] = self._data_type
+
+    def update_node_after_settings_changed(self):
+        self.setup_output_terminals()
 
 
 class Shift8BitNode(ShiftFilterNode):

--- a/src/view/show_mode/editor/nodes/filternode.py
+++ b/src/view/show_mode/editor/nodes/filternode.py
@@ -92,3 +92,7 @@ class FilterNode(Node):
     def filter(self) -> Filter:
         """The corresponding filter"""
         return self._filter
+
+    def update_node_after_settings_changed(self):
+        """Override this method in order to update ports after the settings have changed"""
+        pass


### PR DESCRIPTION
This PR implements the shift filters. Unfortunately it does not work yet as the construction fails while querying the model object. This might affect more filters though as the code was copied and modified from another instance.