### PR TITLE
Fix vfilter univ consolidation

### DIFF
--- a/src/controller/file/serializing/fish_optimizer.py
+++ b/src/controller/file/serializing/fish_optimizer.py
@@ -96,6 +96,8 @@ class SceneOptimizerModule:
             for channel_mapping in channel_list:
                 filter_input_channel, universe_channel, foreign_filter_output_channel = channel_mapping
                 filter_config_parameters[filter_input_channel] = universe_channel
+                if foreign_filter_output_channel in self.channel_override_dict.keys():
+                    foreign_filter_output_channel = self.channel_override_dict.get(foreign_filter_output_channel)
                 channel_mappings[filter_input_channel] = foreign_filter_output_channel
             filter_element = ElementTree.SubElement(scene_element, "filter", attrib={
                 "id": str(self._first_universe_filter_id[universe]),

--- a/src/controller/file/serializing/fish_optimizer.py
+++ b/src/controller/file/serializing/fish_optimizer.py
@@ -95,7 +95,7 @@ class SceneOptimizerModule:
             channel_mappings = dict()
             for channel_mapping in channel_list:
                 filter_input_channel, universe_channel, foreign_filter_output_channel = channel_mapping
-                filter_config_parameters[filter_input_channel] = universe_channel
+                filter_config_parameters[filter_input_channel] = str(int(universe_channel) - 1)
                 if foreign_filter_output_channel in self.channel_override_dict.keys():
                     foreign_filter_output_channel = self.channel_override_dict.get(foreign_filter_output_channel)
                 channel_mappings[filter_input_channel] = foreign_filter_output_channel


### PR DESCRIPTION
There was a bug that causes the universe output optimization to not work if there are vfilters emplaced with direct output to the universe.