### PR TITLE
chg: filternode renderer to use base rendering again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 black
 flake8
 PySide6
-pyqtgraph
+pyqtgraph>=0.13.6
 protobuf
 xmlschema
 pydantic

--- a/src/view/logging_mode/logging_widget.py
+++ b/src/view/logging_mode/logging_widget.py
@@ -80,8 +80,6 @@ class LoggingWidget(QtWidgets.QTabWidget):
         """handle incoming log messages"""
         message_dict = json.loads(message)
         level = message_dict["level"]
-        if level == "WARNING":
-            level = "WARN"
         new_log_item: LoggingItemWidget = LoggingItemWidget(self._tree, message_dict, level,
                                                             self._levels[level].isChecked(), self._loging_level_changed)
         self._log_items.append(new_log_item)

--- a/src/view/logging_mode/logging_widget.py
+++ b/src/view/logging_mode/logging_widget.py
@@ -80,6 +80,8 @@ class LoggingWidget(QtWidgets.QTabWidget):
         """handle incoming log messages"""
         message_dict = json.loads(message)
         level = message_dict["level"]
+        if level == "WARNING":
+            level = "WARN"
         new_log_item: LoggingItemWidget = LoggingItemWidget(self._tree, message_dict, level,
                                                             self._levels[level].isChecked(), self._loging_level_changed)
         self._log_items.append(new_log_item)

--- a/src/view/show_mode/editor/nodes/base/filternode_graphicsitem.py
+++ b/src/view/show_mode/editor/nodes/base/filternode_graphicsitem.py
@@ -12,49 +12,11 @@ class FilterNodeGraphicsItem(NodeGraphicsItem):
     _data_type_brush = QtGui.QBrush(QtGui.QColor(0, 0, 0, 255))
 
     def __init__(self, node):
-        self.terminals = {}
-        self.titleOffset = 25 + 10
-        self.nodeOffset = 12 + 7
         super().__init__(node)
+        self.setTitleOffset(self.titleOffset() + 10)
+        self.setTerminalOffset(self.terminalOffset() + 7)
         from view.show_mode.editor.nodes.type_to_node_dict import type_to_node
         self._node_type_string = type_to_node[self.node.filter.filter_type]
-
-    def updateTerminals(self):
-        # TODO remove this method once the PR got accepted
-        self.terminals = {}
-        inp = self.node.inputs()
-        out = self.node.outputs()
-
-        maxNode = max(len(inp), len(out))
-
-        # calculate new height
-        newHeight = self.titleOffset + maxNode * self.nodeOffset
-
-        # if current height is not equal to new height, update
-        if not self.bounds.height() == newHeight:
-            self.bounds.setHeight(newHeight)
-            self.update()
-
-        # Populate inputs
-        y = self.titleOffset
-        for i, t in inp.items():
-            item = t.graphicsItem()
-            item.setParentItem(self)
-            # item.setZValue(self.zValue()+1)
-            item.setAnchor(0, y)
-            self.terminals[i] = (t, item)
-            y += self.nodeOffset
-
-        # Populate inputs
-        y = self.titleOffset
-        for i, t in out.items():
-            item = t.graphicsItem()
-            item.setParentItem(self)
-            item.setZValue(self.zValue())
-            item.setAnchor(self.bounds.width(), y)
-            self.terminals[i] = (t, item)
-            y += self.nodeOffset
-        # TODO end of code to delete
 
     def paint(self, p: QPainter, *args):
         super().paint(p, *args)
@@ -67,8 +29,8 @@ class FilterNodeGraphicsItem(NodeGraphicsItem):
         p.save()
         p.setBrush(FilterNodeGraphicsItem._data_type_brush)
         p.scale(0.25, 0.25)
-        y_inp = self.titleOffset * 4 + 35
-        y_outp = self.titleOffset * 4 + 35
+        y_inp = self.titleOffset() * 4 + 35
+        y_outp = self.titleOffset() * 4 + 35
         node_width = self.bounds.width()
         for terminal_id, terminal_tuple in self.terminals.items():
             terminal, _ = terminal_tuple
@@ -83,8 +45,8 @@ class FilterNodeGraphicsItem(NodeGraphicsItem):
             terminal_dt_name = str(dt)
             if terminal.isInput():
                 p.drawText(5, y_inp, terminal_dt_name)
-                y_inp += self.nodeOffset * 4
+                y_inp += self.terminalOffset() * 4
             else:
                 p.drawText(node_width * 4 - 8 * len(terminal_dt_name), y_outp, terminal_dt_name)
-                y_outp += self.nodeOffset * 4
+                y_outp += self.terminalOffset() * 4
         p.restore()


### PR DESCRIPTION
A few months ago I contributed a [change](https://github.com/pyqtgraph/pyqtgraph/pull/2869/files) to the pyqtgraph library that made it possible to change the rendering offsets of graph nodes. As this has been now packaged with a new release, we can finally get rid of a lot of redundant code.