### PR TITLE
Optionally hinting functionality of channels

### DIFF
--- a/src/controller/network.py
+++ b/src/controller/network.py
@@ -315,6 +315,7 @@ class NetworkManager(QtCore.QObject):
             xml: xml data to be sent
             goto_default_scene: scene to be loaded
         """
+        #print(ET.tostring(xml, encoding="utf8", method="xml"))
         msg = proto.FilterMode_pb2.load_show_file(
             show_data=ET.tostring(xml, encoding="utf8", method="xml"), goto_default_scene=goto_default_scene
         )
@@ -328,7 +329,7 @@ class NetworkManager(QtCore.QObject):
         """
         if scene.linked_bankset:
             # Todo: Error while calling with cli
-            scene.linked_bankset.activate()
+            scene.linked_bankset.activate(out_of_thread=True)
             print("Activated Bankset")
         else:
             print("No Bankset.")
@@ -338,11 +339,12 @@ class NetworkManager(QtCore.QObject):
         if scene.linked_bankset:
             for f in scene.filters:
                 if f.filter_type in [
-                        FilterTypeEnumeration.FILTER_FADER_RAW,
-                        FilterTypeEnumeration.FILTER_FADER_HSI,
-                        FilterTypeEnumeration.FILTER_FADER_HSIA,
-                        FilterTypeEnumeration.FILTER_FADER_HSIU,
-                        FilterTypeEnumeration.FILTER_FADER_HSIAU]:
+                    FilterTypeEnumeration.FILTER_FADER_RAW,
+                    FilterTypeEnumeration.FILTER_FADER_HSI,
+                    FilterTypeEnumeration.FILTER_FADER_HSIA,
+                    FilterTypeEnumeration.FILTER_FADER_HSIU,
+                    FilterTypeEnumeration.FILTER_FADER_HSIAU
+                ]:
                     self.send_gui_update_to_fish(scene.scene_id, f.filter_id, "set", str(scene.linked_bankset.id),
                                                  enque=not push_direct)
 

--- a/src/view/show_mode/editor/nodes/base/filternode.py
+++ b/src/view/show_mode/editor/nodes/base/filternode.py
@@ -43,6 +43,7 @@ class FilterNode(Node):
         font.setPixelSize(12)
         self.graphicsItem().nameItem.setFont(font)
         self.graphicsItem().xChanged.connect(self.update_filter_pos)
+        self.channel_hints = {}
 
     def graphicsItem(self):
         """Return the GraphicsItem for this node. Subclasses may re-implement

--- a/src/view/show_mode/editor/nodes/base/filternode_graphicsitem.py
+++ b/src/view/show_mode/editor/nodes/base/filternode_graphicsitem.py
@@ -42,7 +42,7 @@ class FilterNodeGraphicsItem(NodeGraphicsItem):
                 dt = self.node.filter.out_data_types.get(terminal.name())
             else:
                 raise ValueError("Expected terminal to be either input or output")
-            terminal_dt_name = str(dt)
+            terminal_dt_name = str(dt) + (self.node.channel_hints.get(terminal.name()) or "")
             if terminal.isInput():
                 p.drawText(5, y_inp, terminal_dt_name)
                 y_inp += self.terminalOffset() * 4

--- a/src/view/show_mode/editor/nodes/impl/effects.py
+++ b/src/view/show_mode/editor/nodes/impl/effects.py
@@ -37,6 +37,7 @@ class CueListNode(FilterNode):
         self.filter.gui_update_keys["run_cue"] = DataType.DT_16_BIT
         self.filter.gui_update_keys["next_cue"] = DataType.DT_16_BIT
         self.filter.default_values['time_scale'] = '1.0'
+        self.channel_hints["time"] = " [ms]"
 
     def parse_and_add_output_channels(self, mappings: str):
         for channel_dev in mappings.split(';'):
@@ -62,6 +63,8 @@ class ShiftFilterNode(FilterNode):
         self.filter.in_data_types["time"] = DataType.DT_DOUBLE
         self.filter.default_values['time'] = '0'
         self.filter.default_values['switch_time'] = '1000'
+        self.channel_hints["switch_time"] = " [ms]"
+        self.channel_hints["time"] = " [ms]"
 
         try:
             if isinstance(model, Scene):

--- a/src/view/show_mode/editor/nodes/impl/time.py
+++ b/src/view/show_mode/editor/nodes/impl/time.py
@@ -15,6 +15,7 @@ class TimeNode(FilterNode):
             'value': {'io': 'out'}
         })
         self.filter.out_data_types["value"] = DataType.DT_DOUBLE
+        self.channel_hints["value"] = " [ms]"
 
 
 class TimeSwitchOnDelay8BitNode(FilterNode):

--- a/src/view/show_mode/editor/nodes/impl/trigonometics.py
+++ b/src/view/show_mode/editor/nodes/impl/trigonometics.py
@@ -27,6 +27,8 @@ class TrigonometricNode(FilterNode):
         self.filter.default_values['factor_inner'] = '0.1'
         self.filter.default_values['phase'] = '0'
         self.filter.default_values['offset'] = '0'
+        self.channel_hints["phase"] = " [deg]"
+        self.channel_hints["value_in"] = " [deg]"
 
 
 class TrigonometricSineNode(TrigonometricNode):


### PR DESCRIPTION
I always need to look up how the effects interpret their inputs and outputs. Therefore I  wrote a little feature to optionally display the usage right next to the data type.

Currently implemented for:
 * trigonometric filters
 * time consuming effects
 * time input