### PR TITLE
fix: typo in channel_label.py

### DIFF
--- a/src/view/show_mode/editor/node_editor_widgets/cue_editor/channel_label.py
+++ b/src/view/show_mode/editor/node_editor_widgets/cue_editor/channel_label.py
@@ -37,7 +37,7 @@ class TimelineChannelLabel(QWidget):
     @property
     def active_channels(self) -> MappingProxyType[str, bool]:
         """Active channels."""
-        return MappingProxyType(self.active_channels)
+        return MappingProxyType(self._active_channels)
 
     @property
     def sb_offset(self) -> int:


### PR DESCRIPTION
During a refactoring, a typo entered the code. This fixes the typo enabling programming of sequencer filters again.