### PR TITLE
add: persistence check box to cue editor

### DIFF
--- a/src/model/filter_data/cues/cue_filter_model.py
+++ b/src/model/filter_data/cues/cue_filter_model.py
@@ -17,10 +17,20 @@ class CueFilterModel:
         self.cues: list[Cue] = []
         self.channels: list[tuple[str, DataType]] = []  # name, data type
         self.global_restart_on_end: bool = False
+        self._persistence_enabled: bool = False
         self._default_cue: int = -1
 
         if parameters is not None:
             self.load_from_configuration(parameters)
+
+    @property
+    def persistence_enabled(self) -> bool:
+        """If true, the filter will recall its configuration after returning to the scene."""
+        return self._persistence_enabled
+
+    @persistence_enabled.setter
+    def persistence_enabled(self, value: bool) -> None:
+        self._persistence_enabled = value
 
     @property
     def default_cue(self) -> int:
@@ -48,7 +58,8 @@ class CueFilterModel:
         else:
             mapping_str = ""
         return {"end_handling": "start_again" if self.global_restart_on_end else "hold", "mapping": mapping_str,
-                "cuelist": "$".join([c.format_cue() for c in self.cues]), "default_cue": str(self.default_cue)}
+                "cuelist": "$".join([c.format_cue() for c in self.cues]), "default_cue": str(self.default_cue),
+                "persistence": "true" if self.persistence_enabled else "false"}
 
     def append_cue(self, c: Cue) -> None:
         """Add a cue to the model."""
@@ -76,6 +87,7 @@ class CueFilterModel:
 
     def load_from_configuration(self, parameters: dict[str, str]) -> None:
         """Deserialize configuration from filter configuration."""
+        self.persistence_enabled = parameters.get("persistence", "false") == "true"
         self.global_restart_on_end = parameters.get("end_handling") == "start_again"
 
         mapping_str = parameters.get("mapping")

--- a/src/view/show_mode/editor/node_editor_widgets/cue_editor/cue_editor_widget.py
+++ b/src/view/show_mode/editor/node_editor_widgets/cue_editor/cue_editor_widget.py
@@ -78,9 +78,11 @@ class CueEditor(PreviewEditWidget):
         if self._bankset:
             self._bankset.update()
             BankSet.push_messages_now()
+        self._persistence_enabled_cb.setChecked(self._model.persistence_enabled)
 
     def _get_configuration(self) -> dict[str, str]:
         self._model.default_cue = self._default_cue_combo_box.currentIndex() - 1
+        self._model.persistence_enabled = self._persistence_enabled_cb.isChecked()
         return self._model.get_as_configuration()
 
     def __init__(self, parent: QWidget = None, f: Filter | None = None) -> None:
@@ -112,6 +114,8 @@ class CueEditor(PreviewEditWidget):
         self._current_cue_another_play_pressed_checkbox.clicked.connect(self._cue_play_pressed_restart_changed)
         self._current_cue_another_play_pressed_checkbox.setEnabled(False)
         cue_settings_container_layout.addRow("", self._current_cue_another_play_pressed_checkbox)
+        self._persistence_enabled_cb = QCheckBox("Enable Persistence", self._parent_widget)
+        cue_settings_container_layout.addWidget(self._persistence_enabled_cb)
 
         cue_settings_container_layout.addRow("Zoom", self.zoom_panel)
         cue_settings_container.setLayout(cue_settings_container_layout)


### PR DESCRIPTION
The persistence check box was missing from the cue editor. This PR adds it.