### PR TITLE
Sequencer Editor missing management functions

### DIFF
--- a/src/model/filter_data/sequencer/sequencer_channel.py
+++ b/src/model/filter_data/sequencer/sequencer_channel.py
@@ -63,6 +63,52 @@ class SequencerChannel:
         """Name of the channel."""
         return self._name
 
+    @property
+    def default_value(self) -> int | float | ColorHSI:
+        """Default value of the channel."""
+        return self._default_value
+
+    @default_value.setter
+    def default_value(self, value: float | ColorHSI) -> None:
+        match self.data_type:
+            case DataType.DT_8_BIT:
+                self._default_value = min(max(int(value), 0), 255)
+            case DataType.DT_16_BIT:
+                self._default_value = min(max(int(value), 0), 65535)
+            case DataType.DT_DOUBLE:
+                self._default_value = float(value)
+            case DataType.DT_COLOR:
+                if not isinstance(value, ColorHSI):
+                    raise ValueError("Expected a color as default value for a color channel.")
+                self._default_value = value
+
+    @property
+    def apply_default_on_empty(self) -> bool:
+        """Whether the default value should be applied on empty transition list."""
+        return self._apply_default_on_empty
+
+    @apply_default_on_empty.setter
+    def apply_default_on_empty(self, value: bool) -> None:
+        self._apply_default_on_empty = value
+
+    @property
+    def apply_default_on_scene_switch(self) -> bool:
+        """Whether the default value should be applied after scene switch."""
+        return self._apply_default_on_scene_switch
+
+    @apply_default_on_scene_switch.setter
+    def apply_default_on_scene_switch(self, value: bool) -> None:
+        self._apply_default_on_scene_switch = value
+
+    @property
+    def interleave_method(self) -> InterleaveMethod:
+        """Interleave method."""
+        return self._interleave_method
+
+    @interleave_method.setter
+    def interleave_method(self, interleave_method: InterleaveMethod) -> None:
+        self._interleave_method = interleave_method
+
     def format_for_filter(self) -> str:
         """Serialize model into filter format."""
         default_value_str = (

--- a/src/view/show_mode/editor/node_editor_widgets/sequencer_editor/channel_edit_dialog.py
+++ b/src/view/show_mode/editor/node_editor_widgets/sequencer_editor/channel_edit_dialog.py
@@ -1,0 +1,107 @@
+"""Contains ChannelEditDialog."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, override
+
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QColorDialog,
+    QDialog,
+    QDoubleSpinBox,
+    QFormLayout,
+    QPushButton,
+    QSpinBox,
+    QWidget,
+)
+
+from model import DataType
+from model.color_hsi import ColorHSI
+from model.filter_data.sequencer.sequencer_channel import SequencerChannel
+from view.show_mode.editor.node_editor_widgets.sequencer_editor.channel_label import ChannelLabel
+from view.show_mode.show_ui_widgets.debug_viz_widgets import ColorLabel
+
+if TYPE_CHECKING:
+    from PySide6 import QtGui
+    from PySide6.QtWidgets import QListWidget
+
+    from view.show_mode.editor.show_browser.annotated_item import AnnotatedListWidgetItem
+
+
+class ChannelEditDialog(QDialog):
+    """Dialog to add mutable channel properties."""
+
+    def __init__(self, channel_item: AnnotatedListWidgetItem, list_widget: QListWidget,
+                 parent: QWidget | None = None) -> None:
+        """Initialize the dialog but does not open it."""
+        super().__init__(parent)
+        self._color_dialog: QColorDialog | None = None
+        self._channel_item = channel_item
+        self._parent_list_widget = list_widget
+        if not isinstance(channel_item.annotated_data, SequencerChannel):
+            raise ValueError("Expected to be provided with a SequencerChannel")
+        self._channel: SequencerChannel = channel_item.annotated_data
+        layout = QFormLayout()
+        if self._channel.data_type == DataType.DT_COLOR:
+            self._cl = ColorLabel()
+            self._cl.set_color(self._channel.default_value)
+            layout.addRow("Default Color", self._cl)
+            change_color_button = QPushButton("Change")
+            change_color_button.clicked.connect(self._change_color_clicked)
+            layout.addRow(change_color_button)
+        elif self._channel.data_type in [DataType.DT_8_BIT, DataType.DT_16_BIT]:
+            self._number_tb = QSpinBox()
+            self._number_tb.setRange(0, 255 if self._channel.data_type == DataType.DT_8_BIT else 65535)
+            self._number_tb.setSingleStep(1)
+            self._number_tb.setValue(self._channel.default_value)
+            self._number_tb.valueChanged.connect(self._number_value_changed)
+            layout.addRow("Default Value:", self._number_tb)
+        else:
+            self._number_tb = QDoubleSpinBox()
+            self._number_tb.setValue(self._channel.default_value)
+            self._number_tb.valueChanged.connect(self._number_value_changed)
+            layout.addRow("Default Value:", self._number_tb)
+
+        self._apply_on_empty_cb = QCheckBox("Apply on empty transition list")
+        self._apply_on_empty_cb.setChecked(self._channel.apply_default_on_empty)
+        self._apply_on_empty_cb.stateChanged.connect(self._apply_on_empty_changed)
+        layout.addWidget(self._apply_on_empty_cb)
+
+        self._apply_on_scene_switch_cb = QCheckBox("Apply on scene switch")
+        self._apply_on_scene_switch_cb.setChecked(self._channel.apply_default_on_scene_switch)
+        self._apply_on_scene_switch_cb.stateChanged.connect(self._apply_on_scene_switch_changed)
+        layout.addWidget(self._apply_on_scene_switch_cb)
+
+        close_button = QPushButton("Done")
+        close_button.clicked.connect(self.close)
+        layout.addWidget(close_button)
+        self.setLayout(layout)
+
+    def _change_color_clicked(self) -> None:
+        self._color_dialog = QColorDialog()
+        self._color_dialog.setCurrentColor(self._channel.default_value.to_qt_color())
+        self._color_dialog.setModal(True)
+        self._color_dialog.accepted.connect(self._color_selected)
+        self._color_dialog.show()
+
+    def _color_selected(self) -> None:
+        self._channel.default_value = ColorHSI.from_qt_color(self._color_dialog.currentColor())
+        self._cl.set_color(self._channel.default_value)
+        self._color_dialog = None
+
+    def _number_value_changed(self) -> None:
+        self._channel.default_value = self._number_tb.value()
+
+    def _apply_on_empty_changed(self) -> None:
+        self._channel.apply_default_on_empty = self._apply_on_empty_cb.isChecked()
+
+    def _apply_on_scene_switch_changed(self) -> None:
+        self._channel.apply_default_on_scene_switch = self._apply_on_scene_switch_cb.isChecked()
+
+    @override
+    def closeEvent(self, event: QtGui.QCloseEvent, /) -> None:
+        self._parent_list_widget.setItemWidget(
+            self._channel_item,
+            ChannelLabel(self._channel, self._parent_list_widget)
+        )
+        super().closeEvent(event)

--- a/src/view/show_mode/editor/node_editor_widgets/sequencer_editor/channel_label.py
+++ b/src/view/show_mode/editor/node_editor_widgets/sequencer_editor/channel_label.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest import case
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QWidget
 
 import style
 from model import DataType
+from view.show_mode.show_ui_widgets.debug_viz_widgets import ColorLabel
 
 if TYPE_CHECKING:
     from model.filter_data.sequencer.sequencer_channel import SequencerChannel
@@ -39,6 +41,19 @@ def generate_datatype_label(parent: QWidget, channel_data_type: DataType) -> QLa
     dtype_label.setFixedWidth(64)
     return dtype_label
 
+
+def _get_default_value_label(channel: SequencerChannel) -> QWidget:
+    """Get a label representing the default value of the channel."""
+    match channel.data_type:
+        case DataType.DT_8_BIT | DataType.DT_16_BIT | DataType.DT_DOUBLE:
+            return QLabel(str(channel.default_value))
+        case DataType.DT_COLOR:
+            cl = ColorLabel()
+            cl.set_color(channel.default_value)
+            return cl
+    return QLabel("Error")
+
+
 class ChannelLabel(QWidget):
     """Label to represent a sequencer channel in a QListWidget."""
 
@@ -52,5 +67,14 @@ class ChannelLabel(QWidget):
         layout.addSpacing(10)
         name_label = QLabel(channel.name)
         layout.addWidget(name_label)
+        layout.addStretch()
+        layout.addWidget(_get_default_value_label(channel))
+        layout.addSpacing(10)
+        if channel.apply_default_on_empty:
+            layout.addWidget(QLabel("E"))
+        if channel.apply_default_on_scene_switch:
+            layout.addWidget(QLabel("S"))
+        layout.addSpacing(10)
+        layout.addWidget(QLabel(channel.interleave_method.name))
         self.setLayout(layout)
         self.setToolTip(channel.tooltip)

--- a/src/view/show_mode/editor/node_editor_widgets/sequencer_editor/channel_label.py
+++ b/src/view/show_mode/editor/node_editor_widgets/sequencer_editor/channel_label.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest import case
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QHBoxLayout, QLabel, QWidget

--- a/src/view/show_mode/editor/node_editor_widgets/sequencer_editor/widget.py
+++ b/src/view/show_mode/editor/node_editor_widgets/sequencer_editor/widget.py
@@ -6,7 +6,8 @@ from logging import getLogger
 from typing import TYPE_CHECKING
 
 from PySide6.QtGui import QAction, Qt
-from PySide6.QtWidgets import QDialog, QListWidget, QMessageBox, QScrollArea, QSplitter, QToolBar, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QDialog, QListWidget, QMessageBox, QScrollArea, QSplitter, QToolBar, QVBoxLayout, QWidget, \
+    QInputDialog
 
 from model.filter_data.sequencer.sequencer_channel import SequencerChannel
 from model.filter_data.sequencer.sequencer_filter_model import SequencerFilterModel
@@ -96,6 +97,10 @@ class SequencerEditor(PreviewEditWidget):
         self._link_event_action.setShortcut("Ctrl+L")
         self._link_event_action.triggered.connect(self._link_event_action_clicked)
         transition_toolbar.addAction(self._link_event_action)
+        self._rename_transition_action = QAction("Rename Transition", transition_toolbar)
+        self._rename_transition_action.setEnabled(False)
+        self._rename_transition_action.triggered.connect(self._rename_transition_triggered)
+        transition_toolbar.addAction(self._rename_transition_action)
         transition_toolbar.addSeparator()
         self._remove_transition_action = QAction("Remove Transition", transition_toolbar)
         self._remove_transition_action.triggered.connect(self._remove_transition_clicked)
@@ -180,12 +185,14 @@ class SequencerEditor(PreviewEditWidget):
             self.set_editing_enabled(True)
             self.transition_add_channel_action.setEnabled(True)
             self._link_event_action.setEnabled(True)
+            self._rename_transition_action.setEnabled(True)
         else:
             self._timeline_container.cue = None
             self._remove_transition_action.setEnabled(False)
             self.set_editing_enabled(False)
             self.transition_add_channel_action.setEnabled(False)
             self._link_event_action.setEnabled(False)
+            self._rename_transition_action.setEnabled(False)
         self._selected_transition = new_transition
         self._recolor_bankset()
 
@@ -463,3 +470,27 @@ class SequencerEditor(PreviewEditWidget):
             return
         self._input_dialog = ChannelEditDialog(selected_channel_items[0], self._channel_list_widget)
         self._input_dialog.show()
+
+    def _rename_transition_triggered(self) -> None:
+        if self._selected_transition is None:
+            logger.error("No transition for renaming selected.")
+            return
+        self._input_dialog = QInputDialog(self._parent_widget)
+        self._input_dialog.setModal(True)
+        self._input_dialog.setInputMode(QInputDialog.InputMode.TextInput)
+        self._input_dialog.setLabelText(f"Please enter a new name for transition '{self._selected_transition.name}'.")
+        self._input_dialog.setWindowTitle("Rename Transition")
+        self._input_dialog.setTextValue(self._selected_transition.name)
+        self._input_dialog.accepted.connect(self._transition_rename_dialog_accepted)
+        self._input_dialog.show()
+
+    def _transition_rename_dialog_accepted(self) -> None:
+        if self._selected_transition is None:
+            logger.error("Expected selected transition for renaming to exist.")
+            return
+        if not isinstance(self._input_dialog, QInputDialog):
+            logger.error("Expected input dialog for renaming to exist.")
+            return
+        self._selected_transition.name = self._input_dialog.textValue()
+        self._transition_widget_map[self._selected_transition].update_labels(self._selected_transition)
+        self._input_dialog = None

--- a/src/view/show_mode/editor/node_editor_widgets/sequencer_editor/widget.py
+++ b/src/view/show_mode/editor/node_editor_widgets/sequencer_editor/widget.py
@@ -6,8 +6,17 @@ from logging import getLogger
 from typing import TYPE_CHECKING
 
 from PySide6.QtGui import QAction, Qt
-from PySide6.QtWidgets import QDialog, QListWidget, QMessageBox, QScrollArea, QSplitter, QToolBar, QVBoxLayout, QWidget, \
-    QInputDialog
+from PySide6.QtWidgets import (
+    QDialog,
+    QInputDialog,
+    QListWidget,
+    QMessageBox,
+    QScrollArea,
+    QSplitter,
+    QToolBar,
+    QVBoxLayout,
+    QWidget,
+)
 
 from model.filter_data.sequencer.sequencer_channel import SequencerChannel
 from model.filter_data.sequencer.sequencer_filter_model import SequencerFilterModel

--- a/src/view/show_mode/editor/node_editor_widgets/sequencer_editor/widget.py
+++ b/src/view/show_mode/editor/node_editor_widgets/sequencer_editor/widget.py
@@ -22,6 +22,7 @@ from view.show_mode.editor.node_editor_widgets.cue_editor.preview_edit_widget im
     PreviewEditWidget,
 )
 from view.show_mode.editor.node_editor_widgets.cue_editor.yes_no_dialog import YesNoDialog
+from view.show_mode.editor.node_editor_widgets.sequencer_editor.channel_edit_dialog import ChannelEditDialog
 from view.show_mode.editor.node_editor_widgets.sequencer_editor.channel_label import ChannelLabel
 from view.show_mode.editor.node_editor_widgets.sequencer_editor.event_selection_dialog import EventSelectionDialog
 from view.show_mode.editor.node_editor_widgets.sequencer_editor.transition_label import TransitionLabel
@@ -65,6 +66,10 @@ class SequencerEditor(PreviewEditWidget):
         add_multi_channel_action = QAction("Add Multiple Channels", channel_toolbar)
         add_multi_channel_action.triggered.connect(self._add_multi_channel_action_triggered)
         channel_toolbar.addAction(add_multi_channel_action)
+        self._edit_channel_action = QAction("Edit Channel", channel_toolbar)
+        self._edit_channel_action.triggered.connect(self._edit_channel_triggered)
+        channel_toolbar.addAction(self._edit_channel_action)
+        channel_toolbar.addSeparator()
         remove_channel_action = QAction("Remove Channel", channel_toolbar)
         remove_channel_action.setShortcut("Ctrl+R")
         remove_channel_action.triggered.connect(self._remove_channel_pressed)
@@ -449,3 +454,12 @@ class SequencerEditor(PreviewEditWidget):
         self._input_dialog = YesNoDialog(
             self.get_widget(), "Live Preview", "Would you like to switch to live preview now?", self._link_bankset
         )
+
+    def _edit_channel_triggered(self) -> None:
+        selected_channel_items = self._channel_list_widget.selectedItems()
+        if len(selected_channel_items) == 0:
+            return
+        if not isinstance(selected_channel_items[0], AnnotatedListWidgetItem):
+            return
+        self._input_dialog = ChannelEditDialog(selected_channel_items[0], self._channel_list_widget)
+        self._input_dialog.show()

--- a/src/view/show_mode/show_ui_widgets/debug_viz_widgets.py
+++ b/src/view/show_mode/show_ui_widgets/debug_viz_widgets.py
@@ -163,6 +163,8 @@ class ColorLabel(QWidget):
         super().__init__(parent)
         self._last_color: tuple[float, float, float] = (0.0, 0.0, 0.0)
         self._last_color_processed: QColor = QColor()
+        self.setMinimumWidth(16)
+        self.setMinimumHeight(16)
 
     def set_color(self, c: ColorHSI) -> None:
         """Set the color to display.


### PR DESCRIPTION
Somehow, the sequence editor is still missing the following features:
- [x] Display of default value, application method and interleaving methods in channel labels
- [x] Edit button to change these properties for a selected channel
- [x] Rename button for transitions